### PR TITLE
#159222976 Add id nonce to ensure new entry Id uniqueness

### DIFF
--- a/server/controllers/addEntry.js
+++ b/server/controllers/addEntry.js
@@ -1,5 +1,5 @@
 import { validationResult } from 'express-validator/check';
-import entries from '../db/entries';
+import { entries, idNonce } from '../db/entries';
 
 const addEntry = (req, res) => {
   const error = validationResult(req);
@@ -7,7 +7,8 @@ const addEntry = (req, res) => {
     return res.status(400).json({ errors: error.array() });
   }
   const entry = req.body;
-  entry.id = entries.length + 1;
+  idNonce.count += 1;
+  entry.id = idNonce.count;
   entries.push(entry);
   return res.status(201).json(entry);
 };

--- a/server/controllers/deleteEntry.js
+++ b/server/controllers/deleteEntry.js
@@ -1,4 +1,4 @@
-import entries from '../db/entries';
+import { entries } from '../db/entries';
 
 const deleteEntry = (req, res) => {
   const indexOfFound = entries.findIndex(entry => entry.id === Number(req.params.id));

--- a/server/controllers/getAllEntries.js
+++ b/server/controllers/getAllEntries.js
@@ -1,4 +1,4 @@
-import entries from '../db/entries';
+import { entries } from '../db/entries';
 
 const getAllEntries = (req, res) => {
   res.status(200).json(entries);

--- a/server/controllers/getEntry.js
+++ b/server/controllers/getEntry.js
@@ -1,4 +1,4 @@
-import entries from '../db/entries';
+import { entries } from '../db/entries';
 
 const getEntry = (req, res) => {
   const found = entries.find(entry => entry.id === Number(req.params.id));

--- a/server/controllers/modifyEntry.js
+++ b/server/controllers/modifyEntry.js
@@ -1,5 +1,5 @@
 import { validationResult } from 'express-validator/check';
-import entries from '../db/entries';
+import { entries } from '../db/entries';
 
 const modifyEntry = (req, res) => {
   const error = validationResult(req);

--- a/server/db/entries.js
+++ b/server/db/entries.js
@@ -19,4 +19,6 @@ const entries = [
   },
 ];
 
-export default entries;
+const idNonce = { count: 2 };
+
+export { entries, idNonce };

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 import app from '../server/index';
-import entries from '../server/db/entries';
+import { entries, idNonce } from '../server/db/entries';
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -65,6 +65,7 @@ describe('/GET/:id entries', () => {
 describe('/POST entries', () => {
   it('should add a new entry to user entries', (done) => {
     const entriesLengthBeforeRequest = entries.length;
+    const idNonceBeforeRequest = Object.assign({}, idNonce);
     const sampleEntry = {
       timestamp: 153677782990,
       title: 'title',
@@ -82,6 +83,7 @@ describe('/POST entries', () => {
         expect(res.body).to.have.property('title', sampleEntry.title);
         expect(res.body).to.have.property('content', sampleEntry.content);
         expect(res.body).to.have.property('isFavorite', sampleEntry.isFavorite);
+        expect(idNonce.count).to.be.eql(idNonceBeforeRequest.count + 1);
         expect(entries.length).to.be.eql(entriesLengthBeforeRequest + 1);
         done();
       });


### PR DESCRIPTION
#### What does this PR do?

Fixes bug that results from deleting an entry and adding a new entry in the previous build. Adding a new entry after a deletion results in entries with the same ids. This bug has been corrected with the use of an id nonce for generating ids for new entries. 
#### Description of Task to be completed

- Add idNonce variable that always increments for every new entry added
- Increment idNonce when user adds a new entry
- Assign id to new entry based on the id of idNonce's count property.
- Integrate idNonce in tests

#### How should this be manually tested?

API endpoint has been deployed to: [https://my-diary-api.herokuapp.com/api/v1](https://my-diary-api.herokuapp.com/api/v1)

Using Postman: 
1. Send a GET request to `/entries` to retrieve a list of all available entries
2. Send a DELETE request to `/entries/:id` for one of the available entries
3. Send a POST request to `/entries` with body
`{
"timestamp": 153462783,
"title": "title",
"content": "content",
"isFavorite": true
}`
4. Repeat step 1 and review the results.
#### What are the relevant pivotal tracker stories?

[#159222976](https://www.pivotaltracker.com/story/show/159222976)