### PR TITLE
#159301048 Show entry creation year on story UI card

### DIFF
--- a/UI/stories.html
+++ b/UI/stories.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,9 +10,10 @@
   <title>My Stories | MyDiary</title>
   <link rel="stylesheet" href="./css/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.css">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins"> 
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Poppins">
   <link rel="icon" type="image/png" href="./img/favicon.png" sizes="32x32" />
 </head>
+
 <body>
   <div class="page page--is-flex page--stretches">
     <header class="header">
@@ -57,7 +59,11 @@
     <div class="container story-list">
       <figure class="story-list__item">
         <div class="item__holder"></div>
-        <div class="item__date"><span class="date__span date__day">28</span><span class="date__span date__month">Apr</span></div>
+        <div class="item__date">
+          <span class="date__span date__day">28</span>
+          <span class="date__span date__month">Apr</span>
+          <span class="date__span date__year">2018</span>
+        </div>
         <figcaption class="item__caption">
           <h3 class="caption__text caption__title">I kissed her</h3>
           <p class="caption__text">It was a dark cold night. We were strolling down the street as I escorted her home</p>
@@ -67,7 +73,11 @@
       </figure>
       <figure class="story-list__item">
         <div class="item__holder"></div>
-        <div class="item__date"><span class="date__span date__day">17</span><span class="date__span date__month">May</span></div>
+        <div class="item__date">
+          <span class="date__span date__day">17</span>
+          <span class="date__span date__month">May</span>
+          <span class="date__span date__year">2018</span>
+        </div>
         <figcaption class="item__caption">
           <h3 class="caption__text caption__title">Broke ass</h3>
           <p class="caption__text">I'm killing time while I wait for life to shower me with meaning and happiness.</p>
@@ -77,17 +87,26 @@
       </figure>
       <figure class="story-list__item">
         <div class="item__holder"></div>
-        <div class="item__date"><span class="date__span date__day">08</span><span class="date__span date__month">June</span></div>
+        <div class="item__date">
+          <span class="date__span date__day">08</span>
+          <span class="date__span date__month">June</span>
+          <span class="date__span date__year">2018</span>
+        </div>
         <figcaption class="item__caption">
           <h3 class="caption__text caption__title">The World Ended Today</h3>
-          <p class="caption__text">So it happened. I got her call. She was to travel to New Zealand. I was happy for her but I knew it had ended. </p>
+          <p class="caption__text">So it happened. I got her call. She was to travel to New Zealand. I was happy for her but I knew it had ended.
+          </p>
         </figcaption>
         <div class="item__overlay">Read Story</div>
         <a class="link item__link" href="story.html?id=3"></a>
       </figure>
       <figure class="story-list__item">
         <div class="item__holder"></div>
-        <div class="item__date"><span class="date__span date__day">08</span><span class="date__span date__month">June</span></div>
+        <div class="item__date">
+          <span class="date__span date__day">08</span>
+          <span class="date__span date__month">June</span>
+          <span class="date__span date__year">2018</span>
+        </div>
         <figcaption class="item__caption">
           <h3 class="caption__text caption__title">So far so good</h3>
           <p class="caption__text">The only skills I have the patience to learn are those that have no real application in life. </p>
@@ -97,7 +116,11 @@
       </figure>
       <figure class="story-list__item">
         <div class="item__holder"></div>
-        <div class="item__date"><span class="date__span date__day">08</span><span class="date__span date__month">June</span></div>
+        <div class="item__date">
+          <span class="date__span date__day">08</span>
+          <span class="date__span date__month">June</span>
+          <span class="date__span date__year">2018</span>
+        </div>
         <figcaption class="item__caption">
           <h3 class="caption__text caption__title">So far so good</h3>
           <p class="caption__text">The only skills I have the patience to learn are those that have no real application in life. </p>
@@ -113,10 +136,13 @@
     </div>
     <footer class="footer">
       <div class="container">
-        <h4> Built with &#10084; by <a class="link" href="https://twitter.com/olusola_dev">Olusola</a></h4>
+        <h4> Built with &#10084; by
+          <a class="link" href="https://twitter.com/olusola_dev">Olusola</a>
+        </h4>
       </div>
     </footer>
   </div>
   <script type="text/javascript" src="./js/main.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
#### What does this PR do?

Adds missing data (year of entry creation) to the date area of each story card 
#### Description of Task to be completed

- Add an extra `<span>` child to the date `<div>` of each story card.

#### How should this be manually tested?

Review the code changes and the screenshots

![screenshot_2018-07-25 my stories mydiary](https://user-images.githubusercontent.com/30433120/43204166-19bfc6aa-9018-11e8-9eef-e8326bf59b93.png)


#### What are the relevant pivotal tracker stories?

[#159301048](https://www.pivotaltracker.com/story/show/159301048)