### PR TITLE
#159328959 Add daily diary update reminder feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,14 @@
         }
       }
     },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -325,6 +333,16 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "dev": true
+    },
+    "asn1.js": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+      "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -1631,6 +1649,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -2419,6 +2442,19 @@
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "escape-html": {
@@ -3779,6 +3815,23 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http_ece": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.0.5.tgz",
+      "integrity": "sha1-tgZg+q8UIVEC0Uk+pyDc2StTNy8=",
+      "requires": {
+        "urlsafe-base64": "~1.0.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -4751,6 +4804,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -9583,6 +9641,11 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -9661,6 +9724,26 @@
         "espree": "^3.5.2",
         "esquery": "^1.0.0",
         "lodash": "^4.17.4"
+      }
+    },
+    "web-push": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.3.2.tgz",
+      "integrity": "sha512-ExPr0dz/IGthbHQqvoZYKsDodEgvET7lyRRuBvC4EjVixlSV7c7jxRRBTVop1XhcbXsBacQTTsA5BJ7/8+x4WA==",
+      "requires": {
+        "asn1.js": "^5.0.0",
+        "http_ece": "1.0.5",
+        "https-proxy-agent": "^2.2.1",
+        "jws": "^3.1.3",
+        "minimist": "^1.2.0",
+        "urlsafe-base64": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pg": "^7.4.3",
     "pg-connection-string": "^2.0.0",
     "swagger-ui-express": "^3.0.10",
+    "web-push": "^3.3.2",
     "yamljs": "^0.3.0"
   },
   "nyc": {

--- a/server/workers/sendReminder.js
+++ b/server/workers/sendReminder.js
@@ -1,0 +1,40 @@
+import 'babel-polyfill';
+import webpush from 'web-push';
+import dotenv from 'dotenv';
+import { query } from '../db/index';
+
+dotenv.config();
+
+// general config
+const pubKey = process.env.PUSH_PUB_KEY;
+const privKey = process.env.PUSH_PRIV_KEY;
+
+webpush.setVapidDetails('https://twitter.com/olusola_dev', pubKey, privKey);
+
+// get all users from database
+const getAllUsers = async () => {
+  const users = await query('SELECT * FROM users');
+  return users.rows;
+};
+
+// TODO: RAM optimization - get users in batches
+const processNotifications = async () => {
+  const users = await getAllUsers().catch(() => {
+    console.error('Could not connect to database');
+  });
+  if (users) {
+    users.forEach(async (user) => {
+      if (user.reminderisset) {
+        const msg = '{ type: reminder }';
+        const options = { TTL: 86400 };
+        await webpush.sendNotification(user.push_sub, msg, options).catch(() => {
+          console.error(`Could not send reminder for user: ${user.email}`);
+        });
+      }
+    });
+  }
+};
+
+processNotifications();
+
+export default processNotifications;

--- a/test/sampleData.js
+++ b/test/sampleData.js
@@ -41,7 +41,11 @@ const sampleData = {
   invalidEntryId: 'id',
   nonExistentId: 5,
   validProfile: {
-    push_sub: JSON.stringify({ channel: 'foo' }),
+    push_sub: JSON.stringify({ keys: 'foo' }),
+    reminder_set: true,
+  },
+  noReminderProfile: {
+    reminder_set: false,
   },
   invalidProfile: {
     reminder_set: '',


### PR DESCRIPTION
#### What does this PR do?

Completes a new feature which enables users to receive daily reminders to update their diary via push notifications
#### Description of Task to be completed

- Add tests for feature
- Implement feature to be able to run in stand-alone mode

#### How should this be manually tested?

- Pull branch into local machine
- Authenticate a push enabled client at https://olusoladavid.github.io/my-diary-client and subscribe for push notifications on the user profile
- `cd my-diary`
- Run `node server/workers/sendNotifications.js` with a valid push subscription
- Receive notification in client

#### What are the relevant pivotal tracker stories?

[#159328959](https://www.pivotaltracker.com/story/show/159328959)